### PR TITLE
Fix overflow during indexing for data with more than 2B entries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* `vroom()` no longer overflows when reading files with more than 2B entries (@wlattner, #183).
+
 * `col_date` now parses single digit month and day (@edzer, #123, #170)
 
 * `vroom_fwf()` now handles files with dos newlines properly.

--- a/src/delimited_index.cc
+++ b/src/delimited_index.cc
@@ -213,7 +213,7 @@ delimited_index::delimited_index(
   }
 
   size_t total_size = std::accumulate(
-      idx_.begin(), idx_.end(), 0, [](size_t sum, const idx_t& v) {
+      idx_.begin(), idx_.end(), std::size_t{0}, [](size_t sum, const idx_t& v) {
         sum += v.size() > 0 ? v.size() - 1 : 0;
         return sum;
       });

--- a/src/delimited_index_connection.cc
+++ b/src/delimited_index_connection.cc
@@ -235,7 +235,7 @@ delimited_index_connection::delimited_index_connection(
   }
 
   size_t total_size = std::accumulate(
-      idx_.begin(), idx_.end(), 0, [](size_t sum, const idx_t& v) {
+      idx_.begin(), idx_.end(), std::size_t{0}, [](size_t sum, const idx_t& v) {
         sum += v.size() > 0 ? v.size() - 1 : 0;
         return sum;
       });


### PR DESCRIPTION
This PR fixes an overflow during indexing. This causes the error below when reading a file with more than 2B entries.

```r
m <- data.frame(x1 = rep(0, 1e9), x2 = rep(1, 1e9), x3 = rep(2, 1e9))

f <- tempfile()
vroom::vroom_write(m, f)

df <- vroom::vroom(f)
#> Error in vroom_(file, delim = delim, col_names = col_names, col_types = col_types,  : 
    Failure to retrieve index 184,467,440,724,145,845 / 6,148,914,690,804,861,440 
```

I am able to reproduce this on MacOS with clang 6 and Ubuntu with gcc 7.4. In both cases, the literal `0` starting value for `std::accumulate` is interpreted as `int` rather than `size_t`.