### PR TITLE
Add pkgdown site as reference URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Description: The goal of 'vroom' is to read and write data (like
     actually use needs to be read.  The writer formats the data in
     parallel and writes to disk asynchronously from formatting.
 License: GPL-3
-URL: https://github.com/r-lib/vroom
+URL: https://vroom.r-lib.org, https://github.com/r-lib/vroom
 BugReports: https://github.com/r-lib/vroom/issues
 Depends: 
     R (>= 3.1)


### PR DESCRIPTION
Enables interpackage linking on pkgdown sites (e.g. `vroom::vroom()` in multidplyr docs will go to vroom's pkgdown function reference instead of rdrr.io)