### PR TITLE
Correctly read double values with comma as decimal separator #313

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * New `vroom(show_col_specs=)` argument to more simply control showing of column specifications after parsing.
 
+* `vroom() correctly reads double values with comma as decimal separator (@kent37 #313)
+
 * `vroom()` no longer inadvertently calls `.name_repair` functions twice (#310).
 
 * Fix an inadvertent performance regression when reading values (#309)

--- a/src/vroom_dbl.h
+++ b/src/vroom_dbl.h
@@ -4,7 +4,7 @@
 #include "parallel.h"
 #include "vroom_vec.h"
 
-double bsd_strtod(const char* begin, const char* end);
+double bsd_strtod(const char* begin, const char* end, const char decimalMark);
 
 cpp11::doubles read_dbl(vroom_vec_info* info);
 
@@ -56,7 +56,9 @@ public:
     double out = parse_value<double>(
         info.column->begin() + i,
         info.column,
-        bsd_strtod,
+        [&](const char* begin, const char* end) -> double {
+          return bsd_strtod(begin, end, info.locale->decimalMark_);
+        },
         info.errors,
         "a double",
         *info.na);

--- a/tests/testthat/test-dbl.R
+++ b/tests/testthat/test-dbl.R
@@ -3,3 +3,14 @@ test_that("Large exponents can parse", {
   expect_equal(res[[1]], 1e-63)
   expect_equal(res[[2]], 1e-64)
 })
+
+test_that("Doubles parse correctly with comma as decimal separator", {
+  res <- vroom(I("23,4\n"), delim='\t', altrep=FALSE,
+               locale=locale(decimal_mark=','),
+               col_types='d', col_names=FALSE)
+  expect_equal(res[[1]], 23.4)
+  res2 <- vroom(I("23,4\n"), delim='\t', altrep=TRUE,
+               locale=locale(decimal_mark=','),
+               col_types='d', col_names=FALSE)
+  expect_equal(res2[[1]], 23.4)
+})


### PR DESCRIPTION
Fixed by providing `decimalMark` to `bsd_strtod` instead of using hard-coded `'.'`.