### PR TITLE
Replace usage of clock with tzdb

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,10 +46,10 @@ Imports:
     rlang (>= 0.4.2),
     stats,
     tibble (>= 2.0.0),
+    tzdb (>= 0.1.0.9001),
     vctrs (>= 0.2.0),
     tidyselect,
-    withr,
-    zones (>= 0.0.0.9000)
+    withr
 Suggests: 
     bench (>= 1.1.0),
     covr,
@@ -73,7 +73,7 @@ Suggests:
 LinkingTo: 
     progress (>= 1.2.1),
     cpp11 (>= 0.2.0),
-    zones (>= 0.0.0.9000)
+    tzdb (>= 0.1.0.9001)
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3
@@ -86,4 +86,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Remotes:
-    r-lib/zones
+    r-lib/tzdb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Imports:
     bit64,
     crayon,
     cli,
-    clock (>= 0.2.0),
     glue,
     hms,
     lifecycle,
@@ -49,7 +48,8 @@ Imports:
     tibble (>= 2.0.0),
     vctrs (>= 0.2.0),
     tidyselect,
-    withr
+    withr,
+    zones (>= 0.0.0.9000)
 Suggests: 
     bench (>= 1.1.0),
     covr,
@@ -71,9 +71,9 @@ Suggests:
     waldo,
     xml2
 LinkingTo: 
-    clock (>= 0.2.0),
     progress (>= 1.2.1),
-    cpp11 (>= 0.2.0)
+    cpp11 (>= 0.2.0),
+    zones (>= 0.0.0.9000)
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3
@@ -85,3 +85,5 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
+Remotes:
+    r-lib/zones

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Imports:
     rlang (>= 0.4.2),
     stats,
     tibble (>= 2.0.0),
-    tzdb (>= 0.1.0.9001),
+    tzdb (>= 0.1.1),
     vctrs (>= 0.2.0),
     tidyselect,
     withr
@@ -73,7 +73,7 @@ Suggests:
 LinkingTo: 
     progress (>= 1.2.1),
     cpp11 (>= 0.2.0),
-    tzdb (>= 0.1.0.9001)
+    tzdb (>= 0.1.1)
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3
@@ -85,5 +85,3 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
-Remotes:
-    r-lib/tzdb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,4 +86,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Remotes:
-    r-lib/zones@feature/error-condition
+    r-lib/zones

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,4 +86,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Remotes:
-    r-lib/zones
+    r-lib/zones@feature/error-condition

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `vroom_lines()` gains a `na` argument.
 
-* vroom now uses the zones package when parsing date-times (@DavisVaughan, #273)
+* vroom now uses the tzdb package when parsing date-times (@DavisVaughan, #273)
 
 * `vroom_write_lines()` now works as intended (#291).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `vroom_lines()` gains a `na` argument.
 
-* vroom now uses the clock package when parsing date-times (@DavisVaughan, #273)
+* vroom now uses the zones package when parsing date-times (@DavisVaughan, #273)
 
 * `vroom_write_lines()` now works as intended (#291).
 

--- a/R/locale.R
+++ b/R/locale.R
@@ -110,7 +110,7 @@ check_tz <- function(x) {
     }
   }
 
-  if (x %in% clock::zone_database_names()) {
+  if (x %in% zones::zone_database_names()) {
     x
   } else {
     stop("Unknown TZ ", x, call. = FALSE)

--- a/R/locale.R
+++ b/R/locale.R
@@ -110,7 +110,7 @@ check_tz <- function(x) {
     }
   }
 
-  if (x %in% zones::zone_database_names()) {
+  if (x %in% tzdb::tzdb_names()) {
     x
   } else {
     stop("Unknown TZ ", x, call. = FALSE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,8 +3,7 @@
 }
 
 .onLoad <- function(...) {
-  # Ensure clock callables are loaded
-  requireNamespace("clock", quietly = TRUE)
+  zones::zones_initialize()
 
   # only register conflicting S3 methods if readr is not already loaded.
   if (!"readr" %in% loadedNamespaces()) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,7 +3,7 @@
 }
 
 .onLoad <- function(...) {
-  zones::zones_initialize()
+  tzdb::tzdb_initialize()
 
   # only register conflicting S3 methods if readr is not already loaded.
   if (!"readr" %in% loadedNamespaces()) {

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -84,13 +84,10 @@ private:
     if (!validDateTime())
       return NA_REAL;
 
-    std::error_condition cnd;
-
     const date::time_zone* p_time_zone;
-    cnd = zones::locate_zone(tz_, p_time_zone);
 
-    if (zones::is_error(cnd)) {
-      throw std::runtime_error(cnd.message());
+    if (!zones::locate_zone(tz_, p_time_zone)) {
+      throw std::runtime_error("'" + tz_ + "' not found in the time zone database.");
     }
 
     const date::local_seconds lt =
@@ -100,10 +97,9 @@ private:
       date::local_days{date::year{year_} / mon_ / day_};
 
     date::local_info info;
-    cnd = zones::get_local_info(lt, p_time_zone, info);
 
-    if (zones::is_error(cnd)) {
-      throw std::runtime_error(cnd.message());
+    if (!zones::get_local_info(lt, p_time_zone, info)) {
+      throw std::runtime_error("Can't lookup local time info for the supplied time zone.");
     }
 
     switch (info.result) {

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -2,7 +2,7 @@
 #define READR_DATE_TIME_H_
 
 #include <cpp11/R.hpp>
-#include <zones/zones.h>
+#include <tzdb/tzdb.h>
 #include <stdlib.h>
 #include <string>
 
@@ -86,7 +86,7 @@ private:
 
     const date::time_zone* p_time_zone;
 
-    if (!zones::locate_zone(tz_, p_time_zone)) {
+    if (!tzdb::locate_zone(tz_, p_time_zone)) {
       throw std::runtime_error("'" + tz_ + "' not found in the time zone database.");
     }
 
@@ -98,7 +98,7 @@ private:
 
     date::local_info info;
 
-    if (!zones::get_local_info(lt, p_time_zone, info)) {
+    if (!tzdb::get_local_info(lt, p_time_zone, info)) {
       throw std::runtime_error("Can't lookup local time info for the supplied time zone.");
     }
 

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -84,12 +84,13 @@ private:
     if (!validDateTime())
       return NA_REAL;
 
-    std::string error;
+    std::error_condition cnd;
 
-    const date::time_zone* p_time_zone = zones::locate_zone(tz_, error);
+    const date::time_zone* p_time_zone;
+    cnd = zones::locate_zone(tz_, p_time_zone);
 
-    if (!error.empty()) {
-      throw std::runtime_error(error);
+    if (zones::is_error(cnd)) {
+      throw std::runtime_error(cnd.message());
     }
 
     const date::local_seconds lt =
@@ -98,10 +99,11 @@ private:
       std::chrono::hours{hour_} +
       date::local_days{date::year{year_} / mon_ / day_};
 
-    const date::local_info info = zones::get_local_info(lt, p_time_zone, error);
+    date::local_info info;
+    cnd = zones::get_local_info(lt, p_time_zone, info);
 
-    if (!error.empty()) {
-      throw std::runtime_error(error);
+    if (zones::is_error(cnd)) {
+      throw std::runtime_error(cnd.message());
     }
 
     switch (info.result) {

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -2,7 +2,7 @@
 #define READR_DATE_TIME_H_
 
 #include <cpp11/R.hpp>
-#include <clock/clock.h>
+#include <zones/zones.h>
 #include <stdlib.h>
 #include <string>
 
@@ -84,7 +84,13 @@ private:
     if (!validDateTime())
       return NA_REAL;
 
-    const date::time_zone* p_time_zone = rclock::locate_zone(tz_);
+    std::string error;
+
+    const date::time_zone* p_time_zone = zones::locate_zone(tz_, error);
+
+    if (!error.empty()) {
+      throw std::runtime_error(error);
+    }
 
     const date::local_seconds lt =
       std::chrono::seconds{sec_} +
@@ -92,7 +98,11 @@ private:
       std::chrono::hours{hour_} +
       date::local_days{date::year{year_} / mon_ / day_};
 
-    const date::local_info info = rclock::get_local_info(lt, p_time_zone);
+    const date::local_info info = zones::get_local_info(lt, p_time_zone, error);
+
+    if (!error.empty()) {
+      throw std::runtime_error(error);
+    }
 
     switch (info.result) {
     case date::local_info::unique:


### PR DESCRIPTION
This PR replaces the usage of clock with [zones](https://github.com/r-lib/zones).

zones is a lightweight way to expose the date library's header API, along with 3 callables for working with time zones. As of [this PR](https://github.com/r-lib/clock/pull/222), clock now uses zones as well, rather than embedding date directly.

I am hopeful that compilation times for vroom should be much faster now. For example, on vroom's Ubuntu r-devel check I see:

> ✔ Built zones 0.0.0.9000 (15.2s)

VS this with clock

> ✔ Built clock 0.2.0 (2m 38.3s)

At the advice of other r-lib co-workers on Slack, the callables now require a `std::string& error` argument. If this is not empty after calling a zones callable, that is the signal that an error has occurred when either loading the time zone or looking up the local time. This is safer than throwing exceptions across packages, at the cost of putting a little more burden on the client (here, vroom).