### PR TITLE
Only re-encode ASCII incompatible encodings

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -1,5 +1,5 @@
-encoding_needs_conversion <- function(encoding) {
-  !encoding %in% c("UTF-8", "latin1", "")
+is_ascii_compatible <- function(encoding) {
+  identical(iconv(list(charToRaw("\n")), from = "ASCII", to = encoding, toRaw = TRUE)[[1]], charToRaw("\n"))
 }
 
 reencode_path <- function(path, encoding) {

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -122,7 +122,7 @@ vroom <- function(
 
   file <- standardise_path(file)
 
-  if (encoding_needs_conversion(locale$encoding)) {
+  if (!is_ascii_compatible(locale$encoding)) {
     file <- reencode_path(file, locale$encoding)
     locale$encoding <- "UTF-8"
   }

--- a/R/vroom_fwf.R
+++ b/R/vroom_fwf.R
@@ -43,7 +43,7 @@ vroom_fwf <- function(file,
 
   file <- standardise_path(file)
 
-  if (encoding_needs_conversion(locale$encoding)) {
+  if (!is_ascii_compatible(locale$encoding)) {
     file <- reencode_path(file, locale$encoding)
     locale$encoding <- "UTF-8"
   }

--- a/R/vroom_lines.R
+++ b/R/vroom_lines.R
@@ -25,7 +25,7 @@ vroom_lines <- function(file, n_max = Inf, skip = 0,
 
   file <- standardise_path(file)
 
-  if (encoding_needs_conversion(locale$encoding)) {
+  if (!is_ascii_compatible(locale$encoding)) {
     file <- reencode_path(file, locale$encoding)
     locale$encoding <- "UTF-8"
   }


### PR DESCRIPTION
We check this dynamically by trying to encode a newline. If it is the
same value as ASCII it will be compatible, so no re-encoding is needed.


On my macOS machine `iconvlist()` knows of 419 encodings, and only the ones below are not byte compatible with ASCII newlines.

I think should work pretty well in practice then, we should only have to re-encode a small number of encodings, though UTF-16 and UCS-2 are pretty common unfortunately.

``` r
is_ascii_compatible <- function(encoding) {
  identical(iconv(list(charToRaw("\n")), from = "ASCII", to = encoding, toRaw = TRUE)[[1]], charToRaw("\n"))
}

x <- purrr::map_lgl(purrr::set_names(iconvlist()), is_ascii_compatible)

x[!x]
#>          CSUCS4       CSUNICODE     CSUNICODE11 ISO-10646-UCS-2 ISO-10646-UCS-4 
#>           FALSE           FALSE           FALSE           FALSE           FALSE 
#>           UCS-2  UCS-2-INTERNAL   UCS-2-SWAPPED         UCS-2BE         UCS-2LE 
#>           FALSE           FALSE           FALSE           FALSE           FALSE 
#>           UCS-4  UCS-4-INTERNAL   UCS-4-SWAPPED         UCS-4BE         UCS-4LE 
#>           FALSE           FALSE           FALSE           FALSE           FALSE 
#>     UNICODE-1-1      UNICODEBIG   UNICODELITTLE          UTF-16        UTF-16BE 
#>           FALSE           FALSE           FALSE           FALSE           FALSE 
#>        UTF-16LE          UTF-32        UTF-32BE        UTF-32LE 
#>           FALSE           FALSE           FALSE           FALSE
```

<sup>Created on 2021-05-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>