### PR TITLE
Avoid an uninitialized `bool` for the CRAN UBSAN check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* Fix uninitialized bool detected by CRAN's USBAN check (https://github.com/r-lib/vroom/pull/386)
+
 * Fix buffer overflow when trying to parse an integer field that is over 64 characters long (https://github.com/tidyverse/readr/issues/1326)
 
 * Fix subset indexing when indexes span a file boundary multiple times (#383)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vroom (development version)
 
-* Fix uninitialized bool detected by CRAN's USBAN check (https://github.com/r-lib/vroom/pull/386)
+* Fix uninitialized bool detected by CRAN's UBSAN check (https://github.com/r-lib/vroom/pull/386)
 
 * Fix buffer overflow when trying to parse an integer field that is over 64 characters long (https://github.com/tidyverse/readr/issues/1326)
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -60,12 +60,12 @@ inline std::pair<bool, bool> is_blank_or_comment_line(
     ++begin;
   }
 
-  bool has_comment;
-  if ((skip_empty_rows && (*begin == '\n' || *begin == '\r')) ||
-      (has_comment =
-           (!comment.empty() &&
-            strncmp(begin, comment.data(), comment.size()) == 0))) {
-    return std::pair<bool, bool>(true, has_comment);
+  if (skip_empty_rows && (*begin == '\n' || *begin == '\r')) {
+    return std::pair<bool, bool>(true, false);
+  }
+
+  if (!comment.empty() && strncmp(begin, comment.data(), comment.size()) == 0) {
+    return std::pair<bool, bool>(true, true);
   }
 
   return std::pair<bool, bool>(false, false);

--- a/src/utils.h
+++ b/src/utils.h
@@ -48,12 +48,16 @@ inline std::pair<bool, bool> is_blank_or_comment_line(
     const char* end,
     const std::string& comment,
     const bool skip_empty_rows) {
+  bool should_skip = false;
+  bool is_comment = false;
+
   if (!skip_empty_rows && comment.empty()) {
-    return std::pair<bool, bool>(false, false);
+    return std::pair<bool, bool>(should_skip, is_comment);
   }
 
   if (skip_empty_rows && (*begin == '\n' || *begin == '\r')) {
-    return std::pair<bool, bool>(true, false);
+    should_skip = true;
+    return std::pair<bool, bool>(should_skip, is_comment);
   }
 
   while (begin < end && (*begin == ' ' || *begin == '\t')) {
@@ -61,14 +65,17 @@ inline std::pair<bool, bool> is_blank_or_comment_line(
   }
 
   if (skip_empty_rows && (*begin == '\n' || *begin == '\r')) {
-    return std::pair<bool, bool>(true, false);
+    should_skip = true;
+    return std::pair<bool, bool>(should_skip, is_comment);
   }
 
   if (!comment.empty() && strncmp(begin, comment.data(), comment.size()) == 0) {
-    return std::pair<bool, bool>(true, true);
+    should_skip = true;
+    is_comment = true;
+    return std::pair<bool, bool>(should_skip, is_comment);
   }
 
-  return std::pair<bool, bool>(false, false);
+  return std::pair<bool, bool>(should_skip, is_comment);
 }
 
 inline bool is_crlf(const char* buf, size_t pos, size_t end) {


### PR DESCRIPTION
i.e. fixes:

```cpp
/usr/local/bin/../include/c++/v1/__utility/pair.h:192:52: runtime error: load of value 128, which is not a valid value for type 'bool'
    #0 0x7f1daea6b953 in std::__1::pair<bool, bool>::pair<bool, bool&, false>(bool&&, bool&) /usr/local/bin/../include/c++/v1/__utility/pair.h:192:52
    #1 0x7f1daea6b3f9 in vroom::is_blank_or_comment_line(char const*, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) /data/gannet/ripley/R/packages/tests-clang-SAN/vroom/src/./utils.h:68:12
```

The first commit is the minimal change required to fix this. I just avoided creating `has_comment` entirely, since it didn't seem to have anything to do with the first half of the if statement.

The second commit slightly refactors the function in a way that I think makes it easier to follow. I originally had trouble knowing what the return value meant, and had to go look for locations where `is_blank_or_comment_line()` was being used to understand how the two `bool` values should be interpreted. Making them local variables with names makes it a bit clearer, IMO. I can revert this one if you disagree.