### PR TITLE
Fix recursive gc error that could occur with POSIXct columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* Fix recursive gc error that could occur when writing POSIXct columns (https://github.com/r-lib/vroom/issues/389)
+
 # vroom 1.5.7
 
 * Jenny Bryan is now the official maintainer.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vroom (development version)
 
-* Fix recursive gc error that could occur when writing POSIXct columns (https://github.com/r-lib/vroom/issues/389)
+* Fix recursive gc error that could occur during `vroom_write()` when `output_column()` generates an ALTREP vector (https://github.com/r-lib/vroom/issues/389)
 
 # vroom 1.5.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vroom (development version)
 
-* Fix recursive gc error that could occur during `vroom_write()` when `output_column()` generates an ALTREP vector (https://github.com/r-lib/vroom/issues/389)
+* Fix recursive gc error that could occur during `vroom_write()` when `output_column()` generates an ALTREP vector (#389).
 
 # vroom 1.5.7
 


### PR DESCRIPTION
Closes #389 

The analysis in this comment was correct https://github.com/r-lib/vroom/issues/389#issuecomment-983667565, the `output_column()` method for POSIXct was creating another character ALTREP vector _after_ `vroom_convert()` was called.

I didn't add a test, because this is hard to test for, but I confirmed that the reprex here no longer errors https://github.com/r-lib/vroom/issues/389#issuecomment-983691057

---

POSIXct isn't necessarily the only type where this could happen.

`output_column.POSIXt()` calls `format()`, and what is happening in `format()` is:

* There is some C code that converts POSIXct -> character and returns a non-altrep character vector called `y`
* At the R level, there is some code that adds names onto `y`
* `names<-` at the C level will create an “ALTREP wrapper” around `y`. It allows you to wrap `y` without duplicating it, and then add new attributes on top of it (like names) cheaply

```r
# part of format.POSIXlt
y <- .Internal(format.POSIXlt(x, format, usetz))
names(y) <- names(x$year)
```

* There is additionally a `structure()` call in `format.POSIXct()` that tries to add names on _again_ to the result of `format.POSIXlt()`. This is probably also creating another ALTREP wrapper layer on top of the first one.

```r
# part of format.POSIXct
structure(format.POSIXlt(as.POSIXlt(x, tz), format, usetz,  ...), names = names(x))
```

So it is entirely possible that other `output_column()` methods could do this, but I don’t think any of the currently implemented ones do.