### PR TITLE
forbid guess_max > n_max.

### DIFF
--- a/R/vroom.R
+++ b/R/vroom.R
@@ -138,6 +138,10 @@ vroom <- function(
     return(tibble::tibble())
   }
 
+  if (!missing(guess_max) && guess_max > n_max) {
+    stop("`guess_max` must be smaller than `n_max`. ", call. = FALSE)
+  }
+
   if (n_max < 0 || is.infinite(n_max)) {
     n_max <- -1
   }

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -348,6 +348,15 @@ test_that("vroom uses the number of rows when guess_max = Inf", {
   expect_equal(res[["x"]][[NROW(res) - 1]], "foo")
 })
 
+test_that("vroom() forbids guess_max > n_max (#392)", {
+  tf <- withr::local_tempfile()
+  df <- tibble::tibble(x = c(NA, NA, 1), y = 1:3)
+  vroom_write(df, tf, delim = "\t")
+
+  expect_error(vroom(tf, n_max = 2, guess_max = 3))
+  expect_error(vroom(tf, n_max = 2, guess_max = Inf))
+})
+
 test_that("vroom adds columns if a row is too short", {
   test_vroom("a,b,c,d\n1,2\n3,4,5,6\n", delim = ",",
     equals = tibble::tibble("a" = c(1,3), "b" = c(2,4), "c" = c(NA, 5), "d" = c(NA, 6))


### PR DESCRIPTION
closes #392

``` r
library(vroom)

tf <- tempfile(fileext = ".csv")
df <- data.frame(x = c(NA, NA, 1), y = 1:3)
write.csv(df, tf, row.names = FALSE)

writeLines(readLines(tf))
#> "x","y"
#> NA,1
#> NA,2
#> 1,3

vroom(tf, delim = ",", n_max = 2, guess_max = 3)
#> Error: `guess_max` must be smaller than `n_max`.
vroom(tf, delim = ",", n_max = 2, guess_max = Inf)
#> Error: `guess_max` must be smaller than `n_max`.
```

<sup>Created on 2021-12-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>