### PR TITLE
Fix the resize and remove workarounds

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -376,9 +376,6 @@ vroom_enquo <- function(x) {
 vroom_select <- function(x, col_select, id) {
   spec <- attr(x, "spec")
 
-  # Drop any NULL columns
-  is_null <- vapply(x, is.null, logical(1))
-  x[is_null] <- NULL
   # reorder and rename columns
   if (inherits(col_select, "quosures") || !quo_is_null(col_select)) {
     if (inherits(col_select, "quosures")) {

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -282,10 +282,6 @@ vroom <- function(
     progress = progress
   )
 
-  # Drop any NULL columns
-  is_null <- vapply(out, is.null, logical(1))
-  out[is_null] <- NULL
-
   # If no rows expand columns to be the same length and names as the spec
   if (NROW(out) == 0) {
     cols <- attr(out, "spec")[["cols"]]

--- a/src/columns.h
+++ b/src/columns.h
@@ -257,7 +257,8 @@ inline cpp11::list create_columns(
     ++i;
   }
 
-  if (i < num_cols) {
+  // use res.size() to finesse presence/absence of filename column
+  if (i < res.size()) {
     // Resize the list appropriately
     SETLENGTH(res, i);
     SET_TRUELENGTH(res, i);


### PR DESCRIPTION
While working on #565, I was puzzled by weird connections between the presence of an `id` column and skipped columns and the order of operations inside `vroom()` and `vroom_fwf()`. I kept pulling on the thread and found that `create_columns()` was failing to resize the output list (literally shrink it) when both `id` and exactly 1 skipped column were present. (The bug doesn't get triggered in the case of >1 skipped columns.) The resize check didn't account for the `id` column offset, causing one spurious `NULL` column to persist at the end of the output list, which would cause `tibble::as_tibble()` to fall over.  I fixed this on the C++ side, which allows us to remove R-side workarounds (placed in 4dec36c94).