### PR TITLE
Non-ascii characters in non-file paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vroom
 Title: Read and Write Rectangular Text Data Quickly
-Version: 1.7.1.9000
+Version: 1.7.1.9001
 Authors@R: c(
     person("Jim", "Hester", role = "aut",
            comment = c(ORCID = "0000-0002-2739-7082")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* Non-ascii characters in non-file paths no longer cause errors with R >= 4.3 (@jonthegeek, #618).
+
 # vroom 1.7.1
 
 * Internal changes requested by CRAN for forward compatibility with clang 22.

--- a/R/path.R
+++ b/R/path.R
@@ -94,7 +94,7 @@ standardise_path <- function(
     return(list(chr_to_file(path, call = call)))
   }
 
-  if (any(grepl("\n", path))) {
+  if (any(grepl("\n", path, useBytes = TRUE))) {
     lifecycle::deprecate_warn(
       "1.5.0",
       "vroom(file = 'must use `I()` for literal data')",
@@ -412,7 +412,7 @@ utils::globalVariables("con")
 chr_to_file <- function(x, call = caller_env()) {
   out <- vroom_tempfile(pattern = "vroom-chr-to-file-")
   con <- file(out, "wb")
-  writeLines(sub("\n$", "", x), con, useBytes = TRUE)
+  writeLines(sub("\n$", "", x, useBytes = TRUE), con, useBytes = TRUE)
   close(con)
 
   withr::defer(unlink(out), envir = call)

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -417,7 +417,7 @@ guess_delim <- function(lines, delims = c(",", "\t", " ", "|", ":", ";")) {
   }
 
   # blank text within quotes
-  lines <- gsub('"[^"]*"', "", lines)
+  lines <- gsub('"[^"]*"', "", lines, useBytes = TRUE)
 
   splits <- lapply(delims, strsplit, x = lines, useBytes = TRUE, fixed = TRUE)
 

--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -73,3 +73,28 @@
       Error:
       ! The package "archive" is required to read `.csv.tar.gz` files.
 
+# can read non-file paths with non-ascii characters (#618)
+
+    Code
+      vroom(I("text\nEl Ni\xf1o was particularly bad this year"), delim = ",",
+      show_col_types = FALSE)
+    Output
+      # A tibble: 1 x 1
+        text                                       
+        <chr>                                      
+      1 "El Ni\xf1o was particularly bad this year"
+
+---
+
+    Code
+      expect_warning({
+        x <- vroom("text\nEl Ni\xf1o was particularly bad this year", delim = ",",
+          show_col_types = FALSE)
+      }, "literal data")
+      x
+    Output
+      # A tibble: 1 x 1
+        text                                       
+        <chr>                                      
+      1 "El Ni\xf1o was particularly bad this year"
+

--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -76,25 +76,25 @@
 # can read non-file paths with non-ascii characters (#618)
 
     Code
-      vroom(I("text\nEl Ni\xf1o was particularly bad this year"), delim = ",",
-      show_col_types = FALSE)
+      vroom(I("text\nEl Ni\xf1o was particularly bad this year"), locale = locale(
+        encoding = "Latin1"), delim = ",", show_col_types = FALSE)
     Output
       # A tibble: 1 x 1
-        text                                       
-        <chr>                                      
-      1 "El Ni\xf1o was particularly bad this year"
+        text                                  
+        <chr>                                 
+      1 El Niño was particularly bad this year
 
 ---
 
     Code
       expect_warning({
-        x <- vroom("text\nEl Ni\xf1o was particularly bad this year", delim = ",",
-          show_col_types = FALSE)
+        x <- vroom("text\nEl Ni\xf1o was particularly bad this year", locale = locale(
+          encoding = "Latin1"), delim = ",", show_col_types = FALSE)
       }, "literal data")
       x
     Output
       # A tibble: 1 x 1
-        text                                       
-        <chr>                                      
-      1 "El Ni\xf1o was particularly bad this year"
+        text                                  
+        <chr>                                 
+      1 El Niño was particularly bad this year
 

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -281,3 +281,26 @@ test_that("reading archive-only formats without archive package fails informativ
     error = TRUE
   )
 })
+
+test_that("can read non-file paths with non-ascii characters (#618)", {
+  expect_snapshot({
+    vroom(
+      I("text\nEl Ni\xf1o was particularly bad this year"),
+      delim = ",",
+      show_col_types = FALSE
+    )
+  })
+  expect_snapshot({
+    expect_warning(
+      {
+        x <- vroom(
+          "text\nEl Ni\xf1o was particularly bad this year",
+          delim = ",",
+          show_col_types = FALSE
+        )
+      },
+      "literal data"
+    )
+    x
+  })
+})

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -283,6 +283,8 @@ test_that("reading archive-only formats without archive package fails informativ
 })
 
 test_that("can read non-file paths with non-ascii characters (#618)", {
+  skip_if(is_windows() && on_github_actions())
+  skip_if(l10n_info()$`Latin-1`)
   expect_snapshot({
     vroom(
       I("text\nEl Ni\xf1o was particularly bad this year"),

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -286,6 +286,7 @@ test_that("can read non-file paths with non-ascii characters (#618)", {
   expect_snapshot({
     vroom(
       I("text\nEl Ni\xf1o was particularly bad this year"),
+      locale = locale(encoding = "Latin1"),
       delim = ",",
       show_col_types = FALSE
     )
@@ -295,6 +296,7 @@ test_that("can read non-file paths with non-ascii characters (#618)", {
       {
         x <- vroom(
           "text\nEl Ni\xf1o was particularly bad this year",
+          locale = locale(encoding = "Latin1"),
           delim = ",",
           show_col_types = FALSE
         )


### PR DESCRIPTION
Adds `useBytes = TRUE` to checks involved in parsing literal inputs.

Fixes #618.