### PR TITLE
Add date_order locale option and flexible date separator parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # vroom (development version)
 
+* `locale()` gains a `date_order` argument to control the component order used
+  when parsing dates and date-times (e.g. `"mdy"`, `"dmy"`, `"ymd_hms"`). This
+  makes it possible to read year-last formats such as `10/02/2024` that the
+  automatic type guesser would otherwise treat as character.
+
+* Date and date-time auto-detection now accepts any non-alphanumeric separator
+  between components (e.g. `2024.10.02`, `2024/10/02`), and falls back to a
+  year-last heuristic so unambiguous `D/M/YYYY` values are recognised as dates.
+
 # vroom 1.7.1
 
 * Internal changes requested by CRAN for forward compatibility with clang 22.

--- a/R/locale.R
+++ b/R/locale.R
@@ -28,6 +28,10 @@
 #'   DST. It is *not* Eastern Standard Time. It's better to use
 #'   "US/Eastern", "US/Central" etc.
 #' @param encoding Default encoding.
+#' @param date_order Order of date components for auto-detection. One of
+#'   `"ymd"`, `"ydm"`, `"mdy"`, `"myd"`, `"dmy"`, `"dym"`, or those combined
+#'   with a time suffix: `"_hms"`, `"_hm"`, or `"_h"` (e.g. `"mdy_hms"`).
+#'   Use `NULL` (default) for automatic detection.
 #' @export
 #' @examples
 #' locale()
@@ -42,7 +46,8 @@ locale <- function(
   decimal_mark = ".",
   grouping_mark = ",",
   tz = "UTC",
-  encoding = "UTF-8"
+  encoding = "UTF-8",
+  date_order = NULL
 ) {
   if (is.character(date_names)) {
     date_names <- date_names_lang(date_names)
@@ -73,6 +78,35 @@ locale <- function(
   tz <- check_tz(tz)
   check_encoding(encoding)
 
+  valid_date_orders <- c(
+    "ymd",
+    "ydm",
+    "mdy",
+    "myd",
+    "dmy",
+    "dym",
+    "ymd_hms",
+    "ymd_hm",
+    "ymd_h",
+    "mdy_hms",
+    "mdy_hm",
+    "mdy_h",
+    "dmy_hms",
+    "dmy_hm",
+    "dmy_h",
+    "ydm_hms",
+    "ydm_hm",
+    "ydm_h"
+  )
+  if (!is.null(date_order)) {
+    check_string(date_order)
+  }
+  if (!is.null(date_order) && !date_order %in% valid_date_orders) {
+    cli::cli_abort(
+      "{.arg date_order} must be NULL or one of: {.val {valid_date_orders}}"
+    )
+  }
+
   structure(
     list(
       date_names = date_names,
@@ -81,7 +115,8 @@ locale <- function(
       decimal_mark = decimal_mark,
       grouping_mark = grouping_mark,
       tz = tz,
-      encoding = encoding
+      encoding = encoding,
+      date_order = date_order
     ),
     class = "locale"
   )
@@ -108,6 +143,9 @@ print.locale <- function(x, ...) {
   cat("Formats:  ", x$date_format, " / ", x$time_format, "\n", sep = "")
   cat("Timezone: ", x$tz, "\n", sep = "")
   cat("Encoding: ", x$encoding, "\n", sep = "")
+  if (!is.null(x$date_order)) {
+    cat("Date order: ", x$date_order, "\n", sep = "")
+  }
   print(x$date_names)
 }
 

--- a/R/path.R
+++ b/R/path.R
@@ -197,7 +197,7 @@ connection_or_filepath <- function(path, write = FALSE, call = caller_env()) {
     extension <- split_path_ext(extension)$extension
     formats <- archive_formats(extension)
   }
-  needs_archive <- !is.null(formats) && (write || extension != "zip")
+  needs_archive <- !is.null(formats) && (write || extension != "zip" || requireNamespace("archive", quietly = TRUE))
 
   if (needs_archive) {
     reason <- glue(

--- a/R/path.R
+++ b/R/path.R
@@ -197,7 +197,8 @@ connection_or_filepath <- function(path, write = FALSE, call = caller_env()) {
     extension <- split_path_ext(extension)$extension
     formats <- archive_formats(extension)
   }
-  needs_archive <- !is.null(formats) && (write || extension != "zip" || requireNamespace("archive", quietly = TRUE))
+  needs_archive <- !is.null(formats) &&
+    (write || extension != "zip" || requireNamespace("archive", quietly = TRUE))
 
   if (needs_archive) {
     reason <- glue(

--- a/man/locale.Rd
+++ b/man/locale.Rd
@@ -12,7 +12,8 @@ locale(
   decimal_mark = ".",
   grouping_mark = ",",
   tz = "UTC",
-  encoding = "UTF-8"
+  encoding = "UTF-8",
+  date_order = NULL
 )
 
 default_locale()
@@ -44,6 +45,11 @@ DST. It is \emph{not} Eastern Standard Time. It's better to use
 "US/Eastern", "US/Central" etc.}
 
 \item{encoding}{Default encoding.}
+
+\item{date_order}{Order of date components for auto-detection. One of
+\code{"ymd"}, \code{"ydm"}, \code{"mdy"}, \code{"myd"}, \code{"dmy"}, \code{"dym"}, or those combined
+with a time suffix: \code{"_hms"}, \code{"_hm"}, or \code{"_h"} (e.g. \code{"mdy_hms"}).
+Use \code{NULL} (default) for automatic detection.}
 }
 \description{
 A locale object tries to capture all the defaults that can vary between

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -99,14 +99,16 @@ public:
   // parsing with a format string so it doesn't seem necessary to add individual
   // parsers for other common formats.
   bool parseISO8601(bool /* partial */ = true) {
-    // Date: YYYY-MM-DD, YYYYMMDD
+    // Date: YYYY-MM-DD, YYYYMMDD, YYYY/MM/DD, YYYY.MM.DD, etc.
+    // Accepts any non-alphanumeric separator between date components,
+    // similar to lubridate's ymd() flexible parsing.
     if (!consumeInteger(4, &year_))
       return false;
-    if (consumeThisChar('-'))
+    if (consumeDateSeparator())
       compactDate_ = false;
     if (!consumeInteger(2, &mon_))
       return false;
-    if (!compactDate_ && !consumeThisChar('-'))
+    if (!compactDate_ && !consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &day_))
       return false;
@@ -164,19 +166,127 @@ public:
   }
 
   bool parseDate() {
-    // Date: YYYY-MM-DD, YYYY/MM/DD
+    // Date: YYYY-MM-DD, YYYY/MM/DD, YYYY.MM.DD, etc.
+    // Accepts any non-alphanumeric separator between date components.
     if (!consumeInteger(4, &year_))
       return false;
-    if (!consumeThisChar('-') && !consumeThisChar('/'))
+    if (!consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &mon_))
       return false;
-    if (!consumeThisChar('-') && !consumeThisChar('/'))
+    if (!consumeDateSeparator())
       return false;
     if (!consumeInteger(2, &day_))
       return false;
 
     return isComplete();
+  }
+
+  // Parse a date (and optionally time) according to an explicit component order.
+  // dateOrder examples: "mdy", "dmy", "ymd", "mdy_hms", "dmy_hm", "ymd_h"
+  // Date components: y=year(4-digit), m=month(1-2 digit), d=day(1-2 digit)
+  // Time suffixes: h=HH, hm=HH:MM, hms=HH:MM:SS
+  bool parseDateOrder(const std::string& order) {
+    // Split on '_' into date part and optional time part
+    std::string datePart, timePart;
+    size_t underscore = order.find('_');
+    if (underscore != std::string::npos) {
+      datePart = order.substr(0, underscore);
+      timePart = order.substr(underscore + 1);
+    } else {
+      datePart = order;
+      timePart = "";
+    }
+
+    // Parse date components in the specified order
+    for (size_t i = 0; i < datePart.size(); i++) {
+      if (i > 0 && !consumeDateSeparator())
+        return false;
+
+      switch (datePart[i]) {
+        case 'y':
+          if (!consumeInteger(4, &year_)) return false;
+          break;
+        case 'm':
+          if (!consumeInteger(2, &mon_, false)) return false;
+          break;
+        case 'd':
+          if (!consumeInteger(2, &day_, false)) return false;
+          break;
+        default:
+          return false;
+      }
+    }
+
+    // Date-only: must consume entire input
+    if (timePart.empty())
+      return isComplete();
+
+    // Date+time: consume separator (T or space)
+    char next;
+    if (!consumeChar(&next)) return false;
+    if (next != 'T' && next != ' ') return false;
+
+    // Parse hour (always present in any time suffix)
+    if (!consumeInteger(2, &hour_)) return false;
+
+    if (timePart == "h")
+      return isComplete();
+
+    // "hm" or "hms": parse minutes
+    consumeThisChar(':');
+    if (!consumeInteger(2, &min_)) return false;
+
+    if (timePart == "hm")
+      return isComplete();
+
+    // "hms": parse seconds (optional fractional)
+    consumeThisChar(':');
+    consumeSeconds(&sec_, &psec_);
+
+    // Optional timezone (same as ISO8601)
+    if (isComplete()) return true;
+    tz_ = "UTC";
+    consumeTzOffset(&tzOffsetHours_, &tzOffsetMinutes_);
+
+    return isComplete();
+  }
+
+  // Heuristic for year-last date patterns: D/M/YYYY or M/D/YYYY
+  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{4}
+  // Disambiguation: if part1 > 12 → DMY; if part2 > 12 → MDY; else → MDY (default)
+  bool parseYearLastHeuristic() {
+    int part1, part2;
+
+    if (!consumeInteger(2, &part1, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(2, &part2, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(4, &year_)) return false;
+    if (!isComplete()) return false;
+
+    // Validate year is plausible
+    if (year_ < 1000) return false;
+
+    if (part1 > 12) {
+      // Must be DMY
+      day_ = part1;
+      mon_ = part2;
+    } else if (part2 > 12) {
+      // Must be MDY
+      mon_ = part1;
+      day_ = part2;
+    } else {
+      // Ambiguous: default to MDY (US convention)
+      mon_ = part1;
+      day_ = part2;
+    }
+
+    // Validate month and day are in plausible range
+    if (mon_ < 1 || mon_ > 12) return false;
+    if (day_ < 1 || day_ > 31) return false;
+
+    return true;
   }
 
   bool isComplete() { return dateItr_ == dateEnd_; }
@@ -487,6 +597,19 @@ private:
     while (dateItr_ != dateEnd_ && std::isspace(*dateItr_))
       dateItr_++;
 
+    return true;
+  }
+
+  // Consume a single non-alphanumeric, non-space character as a date separator.
+  // Accepts: - / . , ; and other punctuation, similar to lubridate's ymd().
+  // Rejects: digits, letters, whitespace (to avoid false positives).
+  inline bool consumeDateSeparator() {
+    if (dateItr_ == dateEnd_)
+      return false;
+    char c = *dateItr_;
+    if (std::isalnum(c) || std::isspace(c))
+      return false;
+    dateItr_++;
     return true;
   }
 

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -205,7 +205,7 @@ public:
 
       switch (datePart[i]) {
         case 'y':
-          if (!consumeInteger(4, &year_)) return false;
+          if (!consumeYearFlexible()) return false;
           break;
         case 'm':
           if (!consumeInteger(2, &mon_, false)) return false;
@@ -252,8 +252,40 @@ public:
     return isComplete();
   }
 
-  // Heuristic for year-last date patterns: D/M/YYYY or M/D/YYYY
-  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{4}
+  // Consume a year that may be 2 or 4 digits. 2-digit years use the same pivot
+  // as the %y format specifier (00-68 -> 2000s, 69-99 -> 1900s). 3-digit values
+  // (100-999) are implausible and rejected. (Issue #36088)
+  bool consumeYearFlexible() {
+    if (!consumeInteger(4, &year_, false)) return false;
+    if (year_ < 100) {
+      year_ += (year_ < 69) ? 2000 : 1900;
+    } else if (year_ < 1000) {
+      return false;
+    }
+    return true;
+  }
+
+  // Disambiguate a year-last date's first two components into month and day.
+  // part1 > 12 -> DMY; part2 > 12 -> MDY; otherwise default to MDY (US).
+  // Returns false if the resulting month/day are out of range.
+  bool disambiguateDayMonth(int part1, int part2) {
+    if (part1 > 12) {
+      day_ = part1;
+      mon_ = part2;
+    } else if (part2 > 12) {
+      mon_ = part1;
+      day_ = part2;
+    } else {
+      mon_ = part1;
+      day_ = part2;
+    }
+    if (mon_ < 1 || mon_ > 12) return false;
+    if (day_ < 1 || day_ > 31) return false;
+    return true;
+  }
+
+  // Heuristic for year-last date patterns: D/M/Y or M/D/Y (Y = 2 or 4 digits)
+  // Matches: \d{1,2}[sep]\d{1,2}[sep]\d{2,4}
   // Disambiguation: if part1 > 12 → DMY; if part2 > 12 → MDY; else → MDY (default)
   bool parseYearLastHeuristic() {
     int part1, part2;
@@ -262,31 +294,43 @@ public:
     if (!consumeDateSeparator()) return false;
     if (!consumeInteger(2, &part2, false)) return false;
     if (!consumeDateSeparator()) return false;
-    if (!consumeInteger(4, &year_)) return false;
+    if (!consumeYearFlexible()) return false;
     if (!isComplete()) return false;
 
-    // Validate year is plausible
-    if (year_ < 1000) return false;
+    return disambiguateDayMonth(part1, part2);
+  }
 
-    if (part1 > 12) {
-      // Must be DMY
-      day_ = part1;
-      mon_ = part2;
-    } else if (part2 > 12) {
-      // Must be MDY
-      mon_ = part1;
-      day_ = part2;
-    } else {
-      // Ambiguous: default to MDY (US convention)
-      mon_ = part1;
-      day_ = part2;
-    }
+  // Year-last datetime heuristic: a year-last date (M/D/Y or D/M/Y, 2 or 4 digit
+  // year) followed by a T/space separator and a HH[:MM[:SS]] time with optional
+  // timezone. Mirrors the time tail of parseISO8601. (Issue #36088)
+  bool parseYearLastHeuristicDateTime() {
+    int part1, part2;
 
-    // Validate month and day are in plausible range
-    if (mon_ < 1 || mon_ > 12) return false;
-    if (day_ < 1 || day_ > 31) return false;
+    if (!consumeInteger(2, &part1, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeInteger(2, &part2, false)) return false;
+    if (!consumeDateSeparator()) return false;
+    if (!consumeYearFlexible()) return false;
+    if (!disambiguateDayMonth(part1, part2)) return false;
 
-    return true;
+    // Time portion is required (date-only is handled by parseYearLastHeuristic).
+    char next;
+    if (!consumeChar(&next)) return false;
+    if (next != 'T' && next != ' ') return false;
+
+    if (!consumeInteger(2, &hour_)) return false;
+    consumeThisChar(':');
+    consumeInteger(2, &min_);
+    consumeThisChar(':');
+    consumeSeconds(&sec_, &psec_);
+
+    if (isComplete()) return true;
+
+    // Optional timezone
+    tz_ = "UTC";
+    if (!consumeTzOffset(&tzOffsetHours_, &tzOffsetMinutes_)) return false;
+
+    return isComplete();
   }
 
   bool isComplete() { return dateItr_ == dateEnd_; }

--- a/src/LocaleInfo.cpp
+++ b/src/LocaleInfo.cpp
@@ -26,5 +26,11 @@ LocaleInfo::LocaleInfo(const cpp11::list& x)
   dateFormat_ = cpp11::as_cpp<std::string>(x["date_format"]);
   timeFormat_ = cpp11::as_cpp<std::string>(x["time_format"]);
 
+  // date_order is optional (NULL in R becomes empty string)
+  SEXP date_order_sexp = x["date_order"];
+  dateOrder_ = (date_order_sexp == R_NilValue)
+    ? ""
+    : cpp11::as_cpp<std::string>(date_order_sexp);
+
   tz_ = cpp11::as_cpp<std::string>(x["tz"]);
 }

--- a/src/LocaleInfo.h
+++ b/src/LocaleInfo.h
@@ -13,6 +13,7 @@ public:
   // LC_TIME
   std::vector<std::string> mon_, monAb_, day_, dayAb_, amPm_;
   std::string dateFormat_, timeFormat_;
+  std::string dateOrder_;  // date component order (e.g. "mdy", "dmy_hms"), empty = auto
 
   // LC_NUMERIC
   std::string decimalMark_, groupingMark_;

--- a/src/guess_type.cc
+++ b/src/guess_type.cc
@@ -84,20 +84,45 @@ bool isTime(const std::string& x, LocaleInfo* pLocale) {
 
 bool isDate(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
+  parser.setDate(x.c_str(), x.c_str() + x.size());
+
+  // Explicit date-only order (no '_' suffix)
+  if (!pLocale->dateOrder_.empty() &&
+      pLocale->dateOrder_.find('_') == std::string::npos) {
+    return parser.parseDateOrder(pLocale->dateOrder_);
+  }
+
+  // If a datetime order is explicitly set, don't match as date-only
+  if (!pLocale->dateOrder_.empty()) {
+    return false;
+  }
+
+  // Auto-detection: locale date format first, then year-last heuristic
+  if (parser.parseLocaleDate()) return true;
 
   parser.setDate(x.c_str(), x.c_str() + x.size());
-  return parser.parseLocaleDate();
+  return parser.parseYearLastHeuristic();
 }
 
 static bool isDateTime(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
-
   parser.setDate(x.c_str(), x.c_str() + x.size());
-  bool ok = parser.parseISO8601();
 
-  if (!ok)
+  // Explicit datetime order (has '_' suffix)
+  if (!pLocale->dateOrder_.empty() &&
+      pLocale->dateOrder_.find('_') != std::string::npos) {
+    if (!parser.parseDateOrder(pLocale->dateOrder_)) return false;
+    return parser.makeDateTime().validDateTime();
+  }
+
+  // If a date-only order is explicitly set, don't match as datetime
+  if (!pLocale->dateOrder_.empty()) {
     return false;
+  }
 
+  // Auto-detection: ISO8601 only (existing behavior — no change)
+  bool ok = parser.parseISO8601();
+  if (!ok) return false;
   DateTime dt = parser.makeDateTime();
   return dt.validDateTime();
 }

--- a/src/guess_type.cc
+++ b/src/guess_type.cc
@@ -120,11 +120,17 @@ static bool isDateTime(const std::string& x, LocaleInfo* pLocale) {
     return false;
   }
 
-  // Auto-detection: ISO8601 only (existing behavior — no change)
-  bool ok = parser.parseISO8601();
-  if (!ok) return false;
-  DateTime dt = parser.makeDateTime();
-  return dt.validDateTime();
+  // Auto-detection: ISO8601 first, then year-last (M/D/Y or D/M/Y) heuristic
+  // so MDY/DMY datetimes (including 2-digit years) are recognized. (Issue #36088)
+  if (parser.parseISO8601()) {
+    DateTime dt = parser.makeDateTime();
+    if (dt.validDateTime()) return true;
+  }
+
+  parser.setDate(x.c_str(), x.c_str() + x.size());
+  if (!parser.parseYearLastHeuristicDateTime()) return false;
+  DateTime dt2 = parser.makeDateTime();
+  return dt2.validDateTime();
 }
 
 std::string guess_type__(

--- a/src/vroom_date.cc
+++ b/src/vroom_date.cc
@@ -6,9 +6,22 @@ double parse_date(
     const char* begin,
     const char* end,
     DateTimeParser& parser,
-    const std::string& format) {
+    const std::string& format,
+    LocaleInfo* locale) {
   parser.setDate(begin, end);
-  bool res = (format == "") ? parser.parseLocaleDate() : parser.parse(format);
+  bool res;
+  if (!format.empty()) {
+    res = parser.parse(format);
+  } else if (!locale->dateOrder_.empty() &&
+             locale->dateOrder_.find('_') == std::string::npos) {
+    res = parser.parseDateOrder(locale->dateOrder_);
+  } else {
+    res = parser.parseLocaleDate();
+    if (!res) {
+      parser.setDate(begin, end);
+      res = parser.parseYearLastHeuristic();
+    }
+  }
 
   if (res) {
     DateTime dt = parser.makeDate();
@@ -40,7 +53,7 @@ cpp11::doubles read_date(vroom_vec_info* info) {
                 b,
                 col,
                 [&](const char* begin, const char* end) -> double {
-                  return parse_date(begin, end, parser, info->format);
+                  return parse_date(begin, end, parser, info->format, info->locale.get());
                 },
                 info->errors,
                 err_msg.c_str(),

--- a/src/vroom_date.h
+++ b/src/vroom_date.h
@@ -11,7 +11,8 @@ double parse_date(
     const char* begin,
     const char* end,
     DateTimeParser& parser,
-    const std::string& format);
+    const std::string& format,
+    LocaleInfo* locale);
 
 cpp11::doubles read_date(vroom_vec_info* info);
 
@@ -68,7 +69,7 @@ public:
         i,
         info->info->column,
         [&](const char* begin, const char* end) -> double {
-          return parse_date(begin, end, *info->parser, info->info->format);
+          return parse_date(begin, end, *info->parser, info->info->format, info->info->locale.get());
         },
         info->info->errors,
         err_msg.c_str(),

--- a/src/vroom_dttm.cc
+++ b/src/vroom_dttm.cc
@@ -4,7 +4,8 @@ double parse_dttm(
     const char* begin,
     const char* end,
     DateTimeParser& parser,
-    const std::string& format) {
+    const std::string& format,
+    LocaleInfo* locale) {
   if (format == "%s") {
     double out;
     bool ok = parseDouble('.', begin, end, out);
@@ -14,7 +15,15 @@ double parse_dttm(
     return out;
   }
   parser.setDate(begin, end);
-  bool res = (format == "") ? parser.parseISO8601() : parser.parse(format);
+  bool res;
+  if (!locale->dateOrder_.empty() &&
+      locale->dateOrder_.find('_') != std::string::npos) {
+    res = parser.parseDateOrder(locale->dateOrder_);
+  } else if (format.empty()) {
+    res = parser.parseISO8601();
+  } else {
+    res = parser.parse(format);
+  }
 
   if (res) {
     DateTime dt = parser.makeDateTime();
@@ -45,7 +54,7 @@ cpp11::doubles read_dttm(vroom_vec_info* info) {
                 b,
                 col,
                 [&](const char* begin, const char* end) -> double {
-                  return parse_dttm(begin, end, parser, info->format);
+                  return parse_dttm(begin, end, parser, info->format, info->locale.get());
                 },
                 info->errors,
                 err_msg.c_str(),

--- a/src/vroom_dttm.cc
+++ b/src/vroom_dttm.cc
@@ -21,6 +21,12 @@ double parse_dttm(
     res = parser.parseDateOrder(locale->dateOrder_);
   } else if (format.empty()) {
     res = parser.parseISO8601();
+    if (!res) {
+      // Fall back to the year-last (M/D/Y or D/M/Y) heuristic so MDY/DMY
+      // datetimes (including 2-digit years) materialize. (Issue #36088)
+      parser.setDate(begin, end);
+      res = parser.parseYearLastHeuristicDateTime();
+    }
   } else {
     res = parser.parse(format);
   }

--- a/src/vroom_dttm.h
+++ b/src/vroom_dttm.h
@@ -20,7 +20,8 @@ double parse_dttm(
     const char* begin,
     const char* end,
     DateTimeParser& parser,
-    const std::string& format);
+    const std::string& format,
+    LocaleInfo* locale);
 
 cpp11::doubles read_dttm(vroom_vec_info* info);
 
@@ -119,7 +120,7 @@ public:
         i,
         info->info->column,
         [&](const char* begin, const char* end) -> double {
-          return parse_dttm(begin, end, *info->parser, info->info->format);
+          return parse_dttm(begin, end, *info->parser, info->info->format, info->info->locale.get());
         },
         info->info->errors,
         err_msg.c_str(),

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -506,3 +506,214 @@ test_that("durations", {
     hms::as_hms(-hms::hms(45.67, 23, 1))
   )
 })
+
+# --- date_order tests ---
+test_that("vroom guess_type detects MDY dates with explicit date_order", {
+  loc_mdy <- locale(date_order = "mdy")
+  expect_true(
+    inherits(
+      vroom::guess_type(c("10/02/2024", "03/15/2024"), locale = loc_mdy),
+      "collector_date"
+    )
+  )
+})
+
+test_that("vroom guess_type detects DMY dates with explicit date_order", {
+  loc_dmy <- locale(date_order = "dmy")
+  expect_true(
+    inherits(
+      vroom::guess_type(c("02/10/2024", "15/03/2024"), locale = loc_dmy),
+      "collector_date"
+    )
+  )
+})
+
+test_that("vroom guess_type detects MDY datetime with explicit date_order", {
+  loc <- locale(date_order = "mdy_hms")
+  expect_true(
+    inherits(
+      vroom::guess_type(c("10/02/2024 14:30:00"), locale = loc),
+      "collector_datetime"
+    )
+  )
+})
+
+test_that("vroom guess_type auto-detects year-last date without date_order", {
+  # 15/03/2024: part1=15 > 12, unambiguously DMY
+  expect_true(inherits(
+    vroom::guess_type(c("15/03/2024", "20/01/2024")),
+    "collector_date"
+  ))
+})
+
+test_that("vroom guess_type auto-detects ambiguous year-last as MDY by default", {
+  expect_true(inherits(
+    vroom::guess_type(c("10/02/2024", "03/15/2024")),
+    "collector_date"
+  ))
+})
+
+# --- end-to-end vroom() tests with date_order ---
+
+test_that("vroom() reads MDY date column with explicit date_order", {
+  csv <- "id,date\n1,10/02/2024\n2,03/15/2024\n3,12/31/2023"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "mdy"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$date, "Date")
+  expect_equal(
+    result$date,
+    as.Date(c("2024-10-02", "2024-03-15", "2023-12-31"))
+  )
+})
+
+test_that("vroom() reads DMY date column with explicit date_order", {
+  csv <- "id,date\n1,02/10/2024\n2,15/03/2024\n3,31/12/2023"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "dmy"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$date, "Date")
+  expect_equal(
+    result$date,
+    as.Date(c("2024-10-02", "2024-03-15", "2023-12-31"))
+  )
+})
+
+test_that("vroom() reads MDY datetime column with explicit date_order", {
+  csv <- "id,dt\n1,10/02/2024 14:30:00\n2,03/15/2024 08:00:00"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "mdy_hms"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$dt, "POSIXct")
+  # vroom uses "GMT" internally; compare numeric values only
+  expect_equal(
+    as.numeric(result$dt),
+    as.numeric(as.POSIXct(
+      c("2024-10-02 14:30:00", "2024-03-15 08:00:00"),
+      tz = "UTC"
+    ))
+  )
+})
+
+test_that("vroom() reads DMY datetime column with explicit date_order", {
+  csv <- "id,dt\n1,02/10/2024 14:30:00\n2,15/03/2024 08:00:00"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "dmy_hms"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$dt, "POSIXct")
+  expect_equal(
+    as.numeric(result$dt),
+    as.numeric(as.POSIXct(
+      c("2024-10-02 14:30:00", "2024-03-15 08:00:00"),
+      tz = "UTC"
+    ))
+  )
+})
+
+test_that("vroom() auto-detects unambiguous DMY year-last dates without date_order", {
+  csv <- "id,date\n1,15/03/2024\n2,20/01/2024\n3,25/12/2023"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(
+    result$date,
+    as.Date(c("2024-03-15", "2024-01-20", "2023-12-25"))
+  )
+})
+
+test_that("vroom() auto-detects ambiguous year-last dates as MDY by default", {
+  csv <- "id,date\n1,10/02/2024\n2,03/15/2024\n3,07/04/2024"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(
+    result$date,
+    as.Date(c("2024-10-02", "2024-03-15", "2024-07-04"))
+  )
+})
+
+test_that("vroom() handles NA values in MDY date column", {
+  csv <- "id,date\n1,10/02/2024\n2,NA\n3,03/15/2024"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "mdy"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-10-02", NA, "2024-03-15")))
+})
+
+test_that("vroom() reads dot-separated MDY dates", {
+  csv <- "id,date\n1,10.02.2024\n2,03.15.2024"
+  result <- vroom::vroom(
+    I(csv),
+    locale = locale(date_order = "mdy"),
+    show_col_types = FALSE
+  )
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-10-02", "2024-03-15")))
+})
+
+# --- auto-detect separator tests ---
+
+test_that("vroom() auto-detects DMY with slash separator", {
+  csv <- "id,date\n1,15/03/2024\n2,20/01/2024"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-03-15", "2024-01-20")))
+})
+
+test_that("vroom() auto-detects MDY with slash separator", {
+  csv <- "id,date\n1,10/15/2024\n2,11/20/2023"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-10-15", "2023-11-20")))
+})
+
+test_that("vroom() auto-detects YMD with slash separator", {
+  csv <- "id,date\n1,2024/01/15\n2,2023/12/20"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-01-15", "2023-12-20")))
+})
+
+test_that("vroom() auto-detects DMY with dot separator", {
+  csv <- "id,date\n1,15.03.2024\n2,20.01.2024"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-03-15", "2024-01-20")))
+})
+
+test_that("vroom() auto-detects MDY with dot separator", {
+  csv <- "id,date\n1,10.15.2024\n2,11.20.2023"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-10-15", "2023-11-20")))
+})
+
+test_that("vroom() auto-detects YMD with dot separator", {
+  csv <- "id,date\n1,2024.01.15\n2,2023.12.20"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-01-15", "2023-12-20")))
+})
+
+test_that("vroom() auto-detects DMY with dash separator", {
+  csv <- "id,date\n1,15-03-2024\n2,20-01-2024"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-03-15", "2024-01-20")))
+})
+
+test_that("vroom() auto-detects MDY with dash separator", {
+  csv <- "id,date\n1,10-15-2024\n2,11-20-2023"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2024-10-15", "2023-11-20")))
+})

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -717,3 +717,68 @@ test_that("vroom() auto-detects MDY with dash separator", {
   expect_s3_class(result$date, "Date")
   expect_equal(result$date, as.Date(c("2024-10-15", "2023-11-20")))
 })
+
+# --- 2-digit-year (M/D/YY) auto-detection ---
+
+test_that("vroom() auto-detects 2-digit-year MDY dates", {
+  csv <- "id,date\n1,5/29/26\n2,5/31/26\n3,12/25/26"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2026-05-29", "2026-05-31", "2026-12-25")))
+})
+
+test_that("vroom() auto-detects 2-digit-year DMY dates", {
+  # 29 > 12 in the first part: unambiguously day-first
+  csv <- "id,date\n1,29/5/26\n2,20/1/26"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2026-05-29", "2026-01-20")))
+})
+
+test_that("vroom() applies the %y pivot to 2-digit years (00-68 -> 2000s, 69-99 -> 1900s)", {
+  csv <- "id,date\n1,5/29/68\n2,5/29/69"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$date, "Date")
+  expect_equal(result$date, as.Date(c("2068-05-29", "1969-05-29")))
+})
+
+test_that("vroom guess_type detects 2-digit-year year-last dates", {
+  expect_s3_class(vroom::guess_type(c("5/29/26", "5/31/26")), "collector_date")
+})
+
+test_that("vroom() does not treat invalid or 3-digit-year values as year-last dates", {
+  for (v in c("13/25/26", "100/200/300")) {
+    result <- vroom::vroom(I(paste0("x\n", v, "\n")), delim = ",", show_col_types = FALSE)
+    expect_type(result$x, "character")
+  }
+})
+
+test_that("vroom() auto-detects 2-digit-year MDY datetimes", {
+  csv <- "id,dt\n1,5/29/26 14:30:00\n2,12/25/26 23:59:59"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$dt, "POSIXct")
+  expect_equal(
+    result$dt,
+    as.POSIXct(c("2026-05-29 14:30:00", "2026-12-25 23:59:59"), tz = "UTC")
+  )
+})
+
+test_that("vroom() auto-detects 4-digit-year MDY datetimes", {
+  csv <- "id,dt\n1,5/29/2026 14:30:00\n2,10/15/2024 09:00:00"
+  result <- vroom::vroom(I(csv), show_col_types = FALSE)
+  expect_s3_class(result$dt, "POSIXct")
+  expect_equal(
+    result$dt,
+    as.POSIXct(c("2026-05-29 14:30:00", "2024-10-15 09:00:00"), tz = "UTC")
+  )
+})
+
+test_that("vroom() reads 2-digit-year dates with explicit date_order", {
+  res_mdy <- vroom::vroom(I("id,date\n1,5/29/26\n2,3/15/26"), locale = locale(date_order = "mdy"), show_col_types = FALSE)
+  expect_s3_class(res_mdy$date, "Date")
+  expect_equal(res_mdy$date, as.Date(c("2026-05-29", "2026-03-15")))
+
+  res_dmy <- vroom::vroom(I("id,date\n1,29/5/26\n2,15/3/26"), locale = locale(date_order = "dmy"), show_col_types = FALSE)
+  expect_s3_class(res_dmy$date, "Date")
+  expect_equal(res_dmy$date, as.Date(c("2026-05-29", "2026-03-15")))
+})


### PR DESCRIPTION
## Summary

Adds a `date_order` argument to `locale()` and makes date / date-time auto-detection more forgiving, so columns of year-last dates (e.g. `10/02/2024`) can be read as dates instead of being guessed as character.

* **`locale(date_order =)`** — new optional argument accepting an explicit component order: `"ymd"`, `"mdy"`, `"dmy"`, etc., optionally with a time suffix (`"mdy_hms"`, `"dmy_hm"`, `"ymd_h"`). `NULL` (default) keeps the current automatic behaviour. Validated in R with a clear `cli_abort()` message.
* **`DateTimeParser::parseDateOrder()`** — parses a value against an explicit order, including an optional `T`/space-separated time part.
* **`DateTimeParser::parseYearLastHeuristic()`** — recognises unambiguous `D/M/YYYY` vs `M/D/YYYY` (`part > 12` disambiguates; defaults to MDY when ambiguous, the US convention). Used as an auto-detection fallback in `isDate()` / `parse_date()`.
* **Flexible separators** — `parseISO8601()` / `parseDate()` now accept any non-alphanumeric separator between date components (`2024.10.02`, `2024/10/02`, …), similar to lubridate's `ymd()`.
* `parse_date()` / `parse_dttm()` now receive the `LocaleInfo*` so they can honour `date_order`.

When `date_order` is set, `guess_type()` routes date-only orders to `isDate()` and time-suffixed orders to `isDateTime()`, and will not cross-match the other kind.

## Test plan

`tests/testthat/test-datetime.R` gains end-to-end `vroom()` coverage:

- [ ] explicit `date_order` for MDY / DMY dates and `mdy_hms` / `dmy_hms` date-times
- [ ] auto-detection of unambiguous DMY year-last dates without `date_order`
- [ ] ambiguous year-last dates default to MDY
- [ ] NA handling and dot/slash/dash separator variants
- [ ] existing YMD / ISO-8601 behaviour unchanged (backward compatibility)