### PR TITLE
fix: allow %e format to parse single-digit days without leading space

### DIFF
--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -474,7 +474,7 @@ private:
     if (consumeThisChar(' '))
       n--;
 
-    return consumeInteger(n, pOut);
+    return consumeInteger(n, pOut, false);
   }
 
   inline bool consumeDouble(double* pOut) {

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -58,6 +58,27 @@ test_that("%e allows leading space", {
   )
 })
 
+test_that("%e parses single-digit day without leading space", {
+  test_parse_date(
+    "January 1, 2010",
+    format = "%B %e, %Y",
+    expected = as.Date("2010-01-01")
+  )
+  test_parse_date(
+    "March 5, 2020",
+    format = "%B %e, %Y",
+    expected = as.Date("2020-03-05")
+  )
+})
+
+test_that("%e parses two-digit day", {
+  test_parse_date(
+    "January 15, 2010",
+    format = "%B %e, %Y",
+    expected = as.Date("2010-01-15")
+  )
+})
+
 test_that("%OS captures partial seconds", {
   test_parse_datetime(
     "2001-01-01 00:00:01.125",


### PR DESCRIPTION
## Problem

The `%e` format specifier (day with optional leading space) fails to parse single-digit days without a leading space. For example:

```r
readr::read_csv(I("d1\nJanuary 1, 2010"), col_types = list(d1 = col_date("%B %e, %Y")))
# Returns NA with parsing failure
```

This is because `consumeIntegerWithSpace` calls `consumeInteger(n, pOut)` with the default `exact = true`, which requires consuming exactly `n` characters. A single-digit day like "1" only consumes 1 character out of the expected 2, causing the parse to fail.

Note that `%d` already handles this correctly — it uses `consumeInteger(2, &day_, false)` with `exact = false`.

## Fix

One-line change in `src/DateTimeParser.h`: pass `exact = false` to `consumeInteger` in `consumeIntegerWithSpace`.

## Tests

Added 2 new test cases:
- `%e` parses single-digit day without leading space ("January 1, 2010")
- `%e` parses two-digit day ("January 15, 2010")

Full test suite passes (4 pre-existing failures in test-path.R related to non-ASCII encoding on macOS, unrelated to this change).

## Related

- Fixes tidyverse/readr#1559