### PR TITLE
fix: skip non-ASCII path tests when locale lacks UTF-8 support

### DIFF
--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -20,7 +20,7 @@
       x <- vroom("a,b,c,d\n1,2,3,4", show_col_types = FALSE)
     Condition
       Warning:
-      The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
+      The `file` argument of `vroom()` must use `I()` for literal data in vroom 1.5.0.
         
         # Bad:
         vroom("X,Y\n1.5,2.3\n")

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -151,6 +151,7 @@ test_that("can write to a tar.gz file if the archive package is available", {
 
 # https://github.com/tidyverse/vroom/issues/394
 test_that("can read file w/o final newline, w/ multi-byte characters in path", {
+  skip_if(!l10n_info()$`UTF-8`)
   pattern <- "no-trailing-n\u00e8wline-m\u00fblti-byt\u00e9-path-"
   tfile <- withr::local_tempfile(pattern = pattern, fileext = ".csv")
   writeChar("a,b\nA,B", con = tfile, eos = NULL)
@@ -163,6 +164,7 @@ test_that("can read file w/o final newline, w/ multi-byte characters in path", {
 
 # for completeness, w.r.t. test above
 test_that("can read file w/ final newline, w/ multi-byte characters in path", {
+  skip_if(!l10n_info()$`UTF-8`)
   pattern <- "yes-trailing-n\u00e8wline-m\u00fblti-byt\u00e9-path-"
   tfile <- withr::local_tempfile(pattern = pattern, fileext = ".csv")
   writeLines(c("a,b", "A,B"), tfile)
@@ -174,6 +176,7 @@ test_that("can read file w/ final newline, w/ multi-byte characters in path", {
 })
 
 test_that("can write to path with non-ascii characters", {
+  skip_if(!l10n_info()$`UTF-8`)
   pattern <- "cr\u00E8me-br\u00FBl\u00E9e-"
   tfile <- withr::local_tempfile(pattern = pattern, fileext = ".csv")
   dat <- tibble::tibble(a = "A", b = "B")
@@ -213,6 +216,7 @@ test_that("can read/write a compressed file with non-ascii characters in path", 
 })
 
 test_that("can read fwf file w/ non-ascii characters in path", {
+  skip_if(!l10n_info()$`UTF-8`)
   tfile <- withr::local_tempfile(pattern = "fwf-y\u00F6-", fileext = ".txt")
   writeLines(c("A B", "C D"), tfile)
 


### PR DESCRIPTION
## What

Four tests in `test-path.R` use Unicode characters in `tempfile()` patterns but fail on systems where the locale is `C` (no UTF-8 support), because `tempfile()` cannot translate the patterns to the native encoding.

This PR adds `skip_if(!l10n_info()$`UTF-8`)` guards to these tests:
- can read file w/o final newline, w/ multi-byte characters in path
- can read file w/ final newline, w/ multi-byte characters in path
- can write to path with non-ascii characters
- can read fwf file w/ non-ascii characters in path

Also updates `_snaps/path.md` to match current lifecycle 1.0.5.9000 wording (`in vroom 1.5.0` instead of `as of vroom 1.5.0`).

## Why

On macOS (and other systems) with `LANG=C` or `LC_CTYPE=C`, these tests fail with:

```
unable to translate 'no-trailing-nèwline-mülti-byté-path-' to native encoding
```

The sibling test at line 184 already has a locale guard (`skip_if(l10n_info()$`Latin-1`)`), but the four affected tests had none.

## Validation

```sh
Rscript -e 'devtools::test()'
# FAIL 0 | WARN 0 | SKIP 9 | PASS 1159
```

All 4 previously-failing tests now correctly skip on non-UTF-8 locales.