### PR TITLE
fix: error when id column name collides with data column (#536)

### DIFF
--- a/R/vroom.R
+++ b/R/vroom.R
@@ -305,6 +305,17 @@ vroom <- function(
 
   out <- tibble::as_tibble(out, .name_repair = identity)
 
+  if (!is.null(id)) {
+    nms <- names(out)
+    data_nms <- nms[-1]
+    if (id %in% data_nms) {
+      cli::cli_abort(
+        "The {.arg id} column name ({.val {id}}) is the same as one of the data column names.",
+        call = caller_env()
+      )
+    }
+  }
+
   out <- vroom_select(out, col_select, id)
   class(out) <- c("spec_tbl_df", class(out))
 

--- a/R/vroom_fwf.R
+++ b/R/vroom_fwf.R
@@ -152,6 +152,17 @@ vroom_fwf <- function(
 
   out <- tibble::as_tibble(out, .name_repair = .name_repair)
 
+  if (!is.null(id)) {
+    nms <- names(out)
+    data_nms <- nms[-1]
+    if (id %in% data_nms) {
+      cli::cli_abort(
+        "The {.arg id} column name ({.val {id}}) is the same as one of the data column names.",
+        call = caller_env()
+      )
+    }
+  }
+
   out <- vroom_select(out, col_select, id)
   class(out) <- c("spec_tbl_df", class(out))
 

--- a/tests/testthat/_snaps/vroom.md
+++ b/tests/testthat/_snaps/vroom.md
@@ -7,3 +7,19 @@
       ! Could not guess the delimiter.
       i Use `vroom(delim =)` to explicitly specify the delimiter.
 
+# id column name collision with data column produces error (#536)
+
+    Code
+      vroom(I("a,hello\n1,2\n"), id = "hello", show_col_types = FALSE)
+    Condition
+      Error:
+      ! The `id` column name ("hello") is the same as one of the data column names.
+
+---
+
+    Code
+      vroom(I("a,b\n1,2\n"), id = "a", show_col_types = FALSE)
+    Condition
+      Error:
+      ! The `id` column name ("a") is the same as one of the data column names.
+

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -1406,3 +1406,20 @@ test_that("vroom(col_select =) output has 'spec_tbl_df' class, spec, and problem
     expect_equal(probs$col, 1)
   }
 })
+
+test_that("id column name collision with data column produces error (#536)", {
+  expect_snapshot(
+    vroom(I("a,hello\n1,2\n"), id = "hello", show_col_types = FALSE),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    vroom(I("a,b\n1,2\n"), id = "a", show_col_types = FALSE),
+    error = TRUE
+  )
+
+  # No error when id name doesn't collide
+  expect_no_error(
+    vroom(I("a,b\n1,2\n"), id = "source", show_col_types = FALSE)
+  )
+})


### PR DESCRIPTION
## What

When `id` is set to the name of an existing data column, `vroom()` previously produced a tibble with duplicate column names. The `.name_repair` argument is applied to data column names before the `id` column is prepended, so the collision was never caught.

Fixes #536.

## Changes

- `R/vroom.R`: Add id column name collision check after tibble construction
- `R/vroom_fwf.R`: Same check for `vroom_fwf()`
- `tests/testthat/test-vroom.R`: Add 3 regression tests (2 error cases, 1 success case)
- `tests/testthat/_snaps/vroom.md`: Auto-generated snapshot for error messages

## Validation

- `R CMD INSTALL .` succeeds
- `devtools::test(filter = "vroom$")`: 0 failures, 351 passes
- `devtools::test(filter = "vroom_fwf")`: 0 failures, 88 passes
- Full test suite: 5 pre-existing failures in test-path.R (locale encoding on macOS), 1161 passes. No new failures introduced.