### PR TITLE
fix: add [.spec_tbl_df method to drop spec/problems on subsetting (#569)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -106,6 +106,16 @@ as.data.frame.spec_tbl_df <- function(x, ...) {
   NextMethod("as.data.frame")
 }
 
+# Conditionally exported in zzz.R
+#' @noRd
+# @export
+`[.spec_tbl_df` <- function(x, ...) {
+  attr(x, "spec") <- NULL
+  attr(x, "problems") <- NULL
+  class(x) <- setdiff(class(x), "spec_tbl_df")
+  NextMethod(`[`)
+}
+
 is_rstudio_console <- function() {
   !(Sys.getenv("RSTUDIO", "") == "" || Sys.getenv("RSTUDIO_TERM", "") != "")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,6 +13,7 @@
     s3_register("base::print", "date_names")
     s3_register("base::print", "locale")
     s3_register("utils::str", "col_spec")
+    s3_register("base::[", "spec_tbl_df")
     s3_register("base::all.equal", "spec_tbl_df")
     s3_register("base::as.data.frame", "spec_tbl_df")
     s3_register("tibble::as_tibble", "spec_tbl_df")

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -1406,3 +1406,23 @@ test_that("vroom(col_select =) output has 'spec_tbl_df' class, spec, and problem
     expect_equal(probs$col, 1)
   }
 })
+
+# https://github.com/tidyverse/vroom/issues/569
+test_that("vroom output drops spec_tbl_df class and attributes on subsetting", {
+  dat <- vroom(
+    I("a,b\n1,2\n3,4\n"),
+    col_types = "dd",
+    show_col_types = FALSE,
+    altrep = FALSE
+  )
+
+  expect_s3_class(dat, "spec_tbl_df")
+  expect_true(!is.null(attr(dat, "spec", exact = TRUE)))
+
+  sub <- dat[1, ]
+
+  expect_s3_class(sub, "tbl_df")
+  expect_false("spec_tbl_df" %in% class(sub))
+  expect_null(attr(sub, "spec", exact = TRUE))
+  expect_null(attr(sub, "problems", exact = TRUE))
+})


### PR DESCRIPTION
Closes #569.

## What

Add a `[.spec_tbl_df` S3 method to vroom that drops the `spec` and `problems` attributes and removes the `spec_tbl_df` subclass when a data frame is subset with `[`.

## Why

When vroom creates a data frame, it applies the `spec_tbl_df` class and attaches `spec` and `problems` attributes. Without a `[.spec_tbl_df` method, these attributes persist after subsetting, which can confuse users and tools that inspect them. readr already has this method; vroom should too.

## Changes

- `R/utils.R`: Add `[.spec_tbl_df` method (same pattern as `as.data.frame.spec_tbl_df`, `as_tibble.spec_tbl_df`, etc.)
- `R/zzz.R`: Register conditionally via `s3_register("base::[", "spec_tbl_df")` when readr is not loaded
- `tests/testthat/test-vroom.R`: Add test verifying that subsetting drops class and attributes

## Validation

- `devtools::test(filter = "vroom$")`: 354 pass, 0 fail
- `devtools::test()`: 1164 pass, 5 pre-existing failures (locale encoding in test-path.R), 0 new failures
- Verified method works both with and without readr loaded