### PR TITLE
docs: clarify FWF positions are byte offsets, add multi-byte test (#622)

### DIFF
--- a/R/vroom_fwf.R
+++ b/R/vroom_fwf.R
@@ -48,6 +48,16 @@
 #' fwf_cols(name = 20, state = 10, ssn = 12)
 #' ```
 #'
+#' @section Multi-byte characters:
+#' Field positions are interpreted as **byte** offsets, not character positions.
+#' For ASCII-only text these are identical, but for multi-byte encodings such as
+#' UTF-8 the two can differ.  For example, the degree symbol `\u00b0` occupies
+#' one character but two bytes.  When a line contains multi-byte characters,
+#' field boundaries specified in character positions will be misaligned.
+#'
+#' If your fixed-width file contains non-ASCII text, count positions by bytes
+#' (e.g. `nchar(x, type = "bytes")`) rather than by characters.
+#'
 #' @inheritParams vroom
 #' @param col_positions Column positions, as created by [fwf_empty()],
 #'   `fwf_widths()`, `fwf_positions()`, or `fwf_cols()`. To read in only

--- a/man/vroom_fwf.Rd
+++ b/man/vroom_fwf.Rd
@@ -233,6 +233,18 @@ fwf_cols(name = c(1, 20), ssn = c(30, 42))
 fwf_cols(name = 20, state = 10, ssn = 12)
 }\if{html}{\out{</div>}}
 }
+\section{Multi-byte characters}{
+
+Field positions are interpreted as \strong{byte} offsets, not character positions.
+For ASCII-only text these are identical, but for multi-byte encodings such as
+UTF-8 the two can differ.  For example, the degree symbol \verb{\\u00b0} occupies
+one character but two bytes.  When a line contains multi-byte characters,
+field boundaries specified in character positions will be misaligned.
+
+If your fixed-width file contains non-ASCII text, count positions by bytes
+(e.g. \code{nchar(x, type = "bytes")}) rather than by characters.
+}
+
 \examples{
 fwf_sample <- vroom_example("fwf-sample.txt")
 writeLines(vroom_lines(fwf_sample))

--- a/tests/testthat/test-vroom_fwf.R
+++ b/tests/testthat/test-vroom_fwf.R
@@ -524,6 +524,32 @@ test_that("vroom_fwf correctly reads DOS files with no trailing newline (https:/
 
 # https://github.com/tidyverse/vroom/issues/554
 # https://github.com/tidyverse/vroom/issues/534
+# https://github.com/tidyverse/vroom/issues/622
+test_that("vroom_fwf interprets positions as byte offsets (#622)", {
+  # The degree symbol ° is 1 character but 2 bytes in UTF-8.
+  # Positions are byte-based, so byte 7 starts at the ° character.
+  lines <- c(
+    "AAAA123456",
+    "BBBB12\u00b0456",
+    "CCCC123456"
+  )
+  out <- vroom_fwf(
+    I(paste(lines, collapse = "\n")),
+    fwf_positions(c(1, 5, 7), c(4, 6, 10), c("f1", "f2", "f3")),
+    col_types = "ccc"
+  )
+
+  # Lines 1 and 3 are pure ASCII: byte and character positions agree.
+  expect_equal(out$f1, c("AAAA", "BBBB", "CCCC"))
+  expect_equal(out$f2, c("12", "12", "12"))
+  expect_equal(out$f3[1], "3456")
+  expect_equal(out$f3[3], "3456")
+
+  # Line 2 contains ° (2 bytes).  Byte 7 is the start of °, so field 3
+  # covers bytes 7-10 which is "\u00b045" (the ° plus two ASCII digits).
+  expect_equal(nchar(out$f3[2], type = "bytes"), 4)
+})
+
 test_that("vroom_fwf(col_select =) output has 'spec_tbl_df' class, spec, and problems when readr is attached", {
   # Register readr's [.spec_tbl_df method which drops attributes and the "spec_tbl_df" class
   readr_single_bracket <- function(x, ...) {


### PR DESCRIPTION
## What

Add a 'Multi-byte characters' section to `vroom_fwf()` documentation explaining that field positions are byte offsets, not character positions. For multi-byte encodings like UTF-8, these differ.

Add a test documenting the current byte-based behavior with the degree symbol (°), which is 1 character but 2 bytes in UTF-8.

## Why

Closes #622. The documentation says 'character positions' but the C++ implementation (`fixed_width_index.h:get()`) uses direct byte offsets into the memory-mapped file. Users working with non-ASCII FWF data hit unexpected field misalignment with no documentation explaining why.

## Changes

- `R/vroom_fwf.R`: Add `@section Multi-byte characters` explaining byte-based positions and advising users to count by bytes with `nchar(x, type = "bytes")`.
- `man/vroom_fwf.Rd`: Regenerated from roxygen source.
- `tests/testthat/test-vroom_fwf.R`: Add test verifying byte-based behavior with the degree symbol.

## Validation

```
Rscript -e 'devtools::test(filter = "vroom_fwf")'
# [ FAIL 0 | WARN 0 | SKIP 0 | PASS 93 ]

Rscript -e 'tools::checkRd("man/vroom_fwf.Rd")'
# (clean)

R CMD build --no-build-vignettes .
R CMD check --no-manual --ignore-vignettes --no-build-vignettes vroom_*.tar.gz
# Status: 1 NOTE (pre-existing non-API entry points), 4 pre-existing test failures (locale issues)
```

## Duplicate check

- No existing PR addresses #622.
- Searched `gh search prs --repo tidyverse/vroom "622" --state open`: no results.